### PR TITLE
rename PathFollowerCmpt

### DIFF
--- a/src/main/java/org/terasology/additionalRails/action/BoosterAction.java
+++ b/src/main/java/org/terasology/additionalRails/action/BoosterAction.java
@@ -18,7 +18,6 @@ package org.terasology.additionalRails.action;
 import com.google.common.collect.Sets;
 import org.terasology.additionalRails.components.BoosterRailComponent;
 import org.terasology.entitySystem.entity.EntityRef;
-import org.terasology.entitySystem.event.EventPriority;
 import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
@@ -29,7 +28,7 @@ import org.terasology.minecarts.blocks.RailComponent;
 import org.terasology.minecarts.components.RailVehicleComponent;
 import org.terasology.minecarts.controllers.CartMotionSystem;
 import org.terasology.registry.In;
-import org.terasology.segmentedpaths.components.SegmentEntityComponent;
+import org.terasology.segmentedpaths.components.PathFollowerComponent;
 import org.terasology.segmentedpaths.events.OnExitSegment;
 import org.terasology.segmentedpaths.events.OnVisitSegment;
 
@@ -57,9 +56,8 @@ public class BoosterAction extends BaseComponentSystem implements UpdateSubscrib
 
     @Override
     public void update(float delta) {
-        segmentEntities.removeIf(entityRef -> !entityRef.exists() || !entityRef.hasComponent(RailVehicleComponent.class) || !entityRef.hasComponent(SegmentEntityComponent.class));
-        for (EntityRef ref: segmentEntities)
-        {
+        segmentEntities.removeIf(entityRef -> !entityRef.exists() || !entityRef.hasComponent(RailVehicleComponent.class) || !entityRef.hasComponent(PathFollowerComponent.class));
+        for (EntityRef ref: segmentEntities) {
             RailVehicleComponent railVehicleComponent = ref.getComponent(RailVehicleComponent.class);
             if(railVehicleComponent.velocity.lengthSquared() < 25f) {
                 Vector3f additionalVelocity = new Vector3f(railVehicleComponent.velocity).normalize().mul((20f / 2.0f) * delta);

--- a/src/main/java/org/terasology/additionalRails/action/LocomotiveAction.java
+++ b/src/main/java/org/terasology/additionalRails/action/LocomotiveAction.java
@@ -27,9 +27,8 @@ import org.terasology.logic.common.ActivateEvent;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.minecarts.components.RailVehicleComponent;
 import org.terasology.minecarts.controllers.CartMotionSystem;
-import org.terasology.physics.components.RigidBodyComponent;
 import org.terasology.registry.In;
-import org.terasology.segmentedpaths.components.SegmentEntityComponent;
+import org.terasology.segmentedpaths.components.PathFollowerComponent;
 
 @RegisterSystem(RegisterMode.AUTHORITY)
 public class LocomotiveAction extends BaseComponentSystem implements UpdateSubscriberSystem {
@@ -41,13 +40,13 @@ public class LocomotiveAction extends BaseComponentSystem implements UpdateSubsc
 
     @Override
     public void update(float delta) {
-        for (EntityRef locomotiveVehicle: entityManager.getEntitiesWith(RailVehicleComponent.class, LocomotiveComponent.class, SegmentEntityComponent.class)) {
+        for (EntityRef locomotiveVehicle: entityManager.getEntitiesWith(RailVehicleComponent.class, LocomotiveComponent.class, PathFollowerComponent.class)) {
             LocomotiveComponent locomotiveComponent = locomotiveVehicle.getComponent(LocomotiveComponent.class);
             RailVehicleComponent railVehicleComponent = locomotiveVehicle.getComponent(RailVehicleComponent.class);
-            SegmentEntityComponent segmentEntityComponent = locomotiveVehicle.getComponent(SegmentEntityComponent.class);
+            PathFollowerComponent pathFollowerComponent = locomotiveVehicle.getComponent(PathFollowerComponent.class);
 
             if(locomotiveComponent.active && railVehicleComponent.velocity.lengthSquared() < 10f) {
-                Vector3f additionalVelocity = new Vector3f(segmentEntityComponent.heading).normalize().mul((20f / 2.0f) * delta);
+                Vector3f additionalVelocity = new Vector3f(pathFollowerComponent.heading).normalize().mul((20f / 2.0f) * delta);
                 railVehicleComponent.velocity.add(additionalVelocity);
                 locomotiveVehicle.saveComponent(railVehicleComponent);
             }


### PR DESCRIPTION
Renamed ambiguous `SegmentEntityCmpt`. to `PathFollowerCmpt`. Also renamed ambiguous variable names. (`t` -> `segmentPosition`)