### PR TITLE
Explosive Cart - GCI Task

### DIFF
--- a/assets/prefabs/items/explosiveCartItem.prefab
+++ b/assets/prefabs/items/explosiveCartItem.prefab
@@ -1,0 +1,14 @@
+{
+    "parent": "engine:iconItem",
+    "DisplayName": {
+        "name": "Explosive Cart"
+    },
+    "Item": {
+        "name": "Explosive Cart",
+        "icon": "Rails:minecart#minecart",
+        "usage": "IN_DIRECTION"
+    },
+    "Rails:CartDefinition": {
+        "prefab" : "AdditionalRails:explosiveCart"
+    }
+}

--- a/assets/prefabs/vehicles/explosiveCart.prefab
+++ b/assets/prefabs/vehicles/explosiveCart.prefab
@@ -1,0 +1,40 @@
+{
+    "Location": {
+        "scale": 0.32
+    },
+    "Mesh": {
+        "mesh": "Rails:minecart",
+        "material": "Rails:minecart"
+    },
+    "RigidBody": {
+        "mass": 250,
+        "collisionGroup": "engine:world",
+        "collidesWith": [
+            "engine:world",
+            "engine:debris",
+            "engine:character",
+            "engine:default"
+        ]
+    },
+    "HullShape": {
+        "sourceMesh" : "Rails:minecart_bounds"
+    },
+    "Health": {
+        "currentHealth": 1,
+        "maxHealth": 1,
+        "regenRate": 1,
+        "waitBeforeRegen": 2,
+        "destroyEntityOnNoHealth" : true
+    },
+    "AdditionalRails:ExplosiveCart" : {},
+    "Rails:RailVehicle": {},
+    "Trigger": {
+        "detectGroups": [
+            "engine:world",
+            "engine:debris",
+            "engine:sensor",
+            "engine:kinematic",
+            "engine:default"
+        ]
+    }
+}

--- a/assets/ui/explosiveCartScreen.ui
+++ b/assets/ui/explosiveCartScreen.ui
@@ -1,0 +1,94 @@
+{
+    "type": "AdditionalRails:ExplosiveCartScreen",
+    "skin": "engine:default",
+    "contents": {
+        "type": "relativeLayout",
+        "contents": [
+            {
+                "type": "UIBox",
+                "layoutInfo": {
+                    "width": 300,
+                    "height": 118,
+                    "position-horizontal-center": {},
+                    "position-vertical-center": {}
+                },
+                "content": {
+                    "type": "relativeLayout",
+                    "contents": [
+                        {
+                            "type": "UILabel",
+                            "id": "screenNameLabel",
+                            "text": "Set fuse length (in seconds)",
+                            "layoutInfo": {
+                                "position-horizontal-center": {},
+                                "use-content-height": true
+                            }
+                        },
+                        {
+                            "type": "UISlider",
+                            "id": "fuseSlider",
+                            "layoutInfo": {
+                                "height": 50,
+                                "position-top": {
+                                    "widget": "screenNameLabel",
+                                    "target": "BOTTOM"
+                                }
+                            },
+                            "value": 4,
+                            "minimum": 0,
+                            "range": 8,
+                            "precision": 1
+                        },
+                        {
+                            "type": "UIButton",
+                            "id": "setBtn",
+                            "text": "Set",
+                            "layoutInfo": {
+                                "use-content-height": true,
+                                "width": 133,
+                                "position-top": {
+                                    "widget": "fuseSlider",
+                                    "target": "BOTTOM"
+                                }
+                            }
+                        },
+                        {
+                            "type": "UISpace",
+                            "id": "space",
+                            "size": [1, 1],
+                            "layoutInfo": {
+                                "use-content-height": true,
+                                "width": 9,
+                                "position-top": {
+                                    "widget": "fuseSlider",
+                                    "target": "BOTTOM"
+                                },
+                                "position-left": {
+                                    "widget": "setBtn",
+                                    "target": "RIGHT"
+                                }
+                            }
+                        },
+                        {
+                            "type": "UIButton",
+                            "id": "cancelBtn",
+                            "text": "Close",
+                            "layoutInfo": {
+                                "use-content-height": true,
+                                "width": 133,
+                                "position-top": {
+                                    "widget": "fuseSlider",
+                                    "target": "BOTTOM"
+                                },
+                                "position-left": {
+                                    "widget": "space",
+                                    "target": "RIGHT"
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+}

--- a/src/main/java/org/terasology/additionalRails/action/ExplosiveCartAction.java
+++ b/src/main/java/org/terasology/additionalRails/action/ExplosiveCartAction.java
@@ -1,0 +1,74 @@
+package org.terasology.additionalRails.action;
+
+import org.terasology.additionalRails.components.ExplosiveCartComponent;
+import org.terasology.additionalRails.events.CartActivatedEvent;
+import org.terasology.additionalRails.ui.ExplosiveCartScreen;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.ReceiveEvent;
+import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.RegisterMode;
+import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.logic.actions.ExplosionActionComponent;
+import org.terasology.logic.actions.ExplosionAuthoritySystem;
+import org.terasology.logic.common.ActivateEvent;
+import org.terasology.logic.delay.DelayManager;
+import org.terasology.logic.delay.DelayedActionTriggeredEvent;
+import org.terasology.logic.location.LocationComponent;
+import org.terasology.registry.In;
+import org.terasology.rendering.nui.NUIManager;
+
+/**
+ * System covering Explosive Cart's behavior.
+ * @author Aleksander Wójtowicz <anuar2k@outlook.com>
+ */
+@RegisterSystem(RegisterMode.AUTHORITY)
+public class ExplosiveCartAction extends BaseComponentSystem {
+    static final String CART_EXPLOSION_ACTION_ID = "CART_EXPLOSION";
+    static final String SCREEN_URI = "AdditionalRails:ExplosiveCartScreen";
+
+    @In
+    DelayManager delayManager;
+    @In
+    NUIManager nuiManager;
+
+    /**
+     * Called when cart enters the Activator Rail. The "CART_EXPLOSION" DelayedAction is set for {@link ExplosiveCartComponent} fuseLengthMs.
+     * @param event called by Activator Rail.
+     * @param entity of the cart.
+     * @param ecComponent carrying information how long is the fuse.
+     */
+    @ReceiveEvent(components = {ExplosiveCartComponent.class, LocationComponent.class})
+    public void onActivateFuseOnCart(CartActivatedEvent event, EntityRef entity, ExplosiveCartComponent ecComponent) {
+        delayManager.addDelayedAction(entity, CART_EXPLOSION_ACTION_ID, ecComponent.fuseLengthMs);
+    }
+
+    /**
+     * Called when "CART_EXPLOSION" DelayedAction is triggered.
+     * The {@link ExplosionActionComponent} is added to the cart's entity just before exploding, because every entity carrying it explodes on {@link ActivateEvent} (it's defined in {@link ExplosionAuthoritySystem}.
+     * We don't want to make our cart do that. This is the reason why we can't have the cart carrying {@link ExplosionActionComponent} and why we can't set "DELAYED_EXPLOSION" action from the beginning.
+     * @param event called by {@link DelayManager}.
+     * @param entity of the cart.
+     * @param ecComponent differentiating Explosive Cart from others.
+     */
+    @ReceiveEvent(components = {ExplosiveCartComponent.class, LocationComponent.class})
+    public void onFuseBurnt(DelayedActionTriggeredEvent event, EntityRef entity, ExplosiveCartComponent ecComponent) {
+        if (event.getActionId().equals(CART_EXPLOSION_ACTION_ID)) {
+            entity.addComponent(new ExplosionActionComponent());
+            //DelayedActionTriggeredEvent is sent without the delay (what a paradox lol) to ka-boom-kachow the cart.
+            entity.send(new DelayedActionTriggeredEvent(ExplosionAuthoritySystem.DELAYED_EXPLOSION_ACTION_ID));
+        }
+    }
+
+    /**
+     * Opens up a UI window in which you can set the cart's fuse length.
+     * @param event called by the player.
+     * @param entity of the cart.
+     * @param ecComponent differentiating Explosive Cart from others.
+     */
+    @ReceiveEvent(components = {ExplosiveCartComponent.class, LocationComponent.class})
+    public void onActivatedByPlayer(ActivateEvent event, EntityRef entity, ExplosiveCartComponent ecComponent) {
+        nuiManager.toggleScreen(SCREEN_URI);
+        ExplosiveCartScreen screen = (ExplosiveCartScreen)nuiManager.getScreen(SCREEN_URI);
+        screen.attachToEntity(entity);
+    }
+}

--- a/src/main/java/org/terasology/additionalRails/components/ExplosiveCartComponent.java
+++ b/src/main/java/org/terasology/additionalRails/components/ExplosiveCartComponent.java
@@ -1,0 +1,14 @@
+package org.terasology.additionalRails.components;
+
+import org.terasology.entitySystem.Component;
+
+/**
+ * Component differentiating Explosive Cart.
+ * @author Aleksander Wójtowicz <anuar2k@outlook.com>
+ */
+public class ExplosiveCartComponent implements Component {
+    /**
+     * Defines how long does it take to make the cart explode after being activated by Activator Rail.
+     */
+    public long fuseLengthMs = 4000;
+}

--- a/src/main/java/org/terasology/additionalRails/ui/ExplosiveCartScreen.java
+++ b/src/main/java/org/terasology/additionalRails/ui/ExplosiveCartScreen.java
@@ -1,0 +1,60 @@
+package org.terasology.additionalRails.ui;
+
+import org.terasology.additionalRails.components.ExplosiveCartComponent;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.rendering.nui.CoreScreenLayer;
+import org.terasology.rendering.nui.widgets.UIButton;
+import org.terasology.rendering.nui.widgets.UISlider;
+
+/**
+ * Explosive Cart's fuse length configurator's backend.
+ * @author Aleksander Wójtowicz <anuar2k@outlook.com>
+ */
+public class ExplosiveCartScreen extends CoreScreenLayer {
+    private EntityRef cartEntity;
+
+    private UISlider slider;
+    private UIButton setBtn;
+    private UIButton cancelBtn;
+
+    /**
+     * UI Window setup.
+     */
+    @Override
+    public void initialise() {
+        slider = find("fuseSlider", UISlider.class);
+        setBtn = find("setBtn", UIButton.class);
+        cancelBtn = find("cancelBtn", UIButton.class);
+
+        if (setBtn != null) {
+            setBtn.subscribe(button -> {
+                if (cartEntity.hasComponent(ExplosiveCartComponent.class)) {
+                    if (slider != null) {
+                        ExplosiveCartComponent ecComponent = cartEntity.getComponent(ExplosiveCartComponent.class);
+                        ecComponent.fuseLengthMs = Math.round(slider.getValue()*1000);
+                    }
+                }
+                triggerBackAnimation();
+            });
+        }
+
+        if (cancelBtn != null) {
+            cancelBtn.subscribe(button -> triggerBackAnimation());
+        }
+    }
+
+    /**
+     * Called everytime in {@link org.terasology.additionalRails.action.ExplosiveCartAction} when the window gets opened.
+     * @param cartEntity of the Explosive Cart.
+     */
+    public void attachToEntity(EntityRef cartEntity) {
+        this.cartEntity = cartEntity;
+        if (cartEntity.hasComponent(ExplosiveCartComponent.class)) {
+            if (slider != null) {
+                ExplosiveCartComponent ecComponent = cartEntity.getComponent(ExplosiveCartComponent.class);
+                slider.setValue(ecComponent.fuseLengthMs / 1000f);
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
Instead of including Custom Model, I've added a different bonus - UI Screen displayed upon activation of the cart allowing to set the fuse's length.

I have also made a PR to the Terasology main which is required by this PR here:
https://github.com/MovingBlocks/Terasology/pull/3195

I've tried to do my task without modifying the game source, but finding the closest block upon explosion to make it explode instead of the cart would be game-breaking, because if the cart gets stuck inside "unbreakable" block it would be actually removed.

There's also an issue related to my work (common to all explosions destroying rails):
https://github.com/Terasology/Rails/issues/32